### PR TITLE
[hadess-sensorfw-proxy] Skip FaceDown and FaceUp events

### DIFF
--- a/iio-sensor-proxy.cpp
+++ b/iio-sensor-proxy.cpp
@@ -833,10 +833,8 @@ int main (int argc, char **argv)
 					orientation = ORIENTATION_NORMAL;
 					break;
 				case repowerd::OrientationData::FaceDown:
-					orientation = ORIENTATION_NORMAL;
-					break;
 				case repowerd::OrientationData::FaceUp:
-					orientation = ORIENTATION_NORMAL;
+					/* Skip FaceDown/FaceUp events */
 					break;
 				default:
 					orientation = ORIENTATION_UNDEFINED;


### PR DESCRIPTION
Previously, FaceDown and FaceUp events would return ORIENTATION_NORMAL (i.e. the
standard portrait orientation).

This meant that placing the device down in a surface would reset the orientation
to portrait even when the device's real orientation is actually landscape.

Let's skip those events altogether - iio-sensor-proxy doesn't actually support
them anyways.